### PR TITLE
Fix Cubism web sample Dockerfile

### DIFF
--- a/CubismSdkForWeb-5-r.4/Dockerfile
+++ b/CubismSdkForWeb-5-r.4/Dockerfile
@@ -1,7 +1,19 @@
 FROM node:18-alpine
-WORKDIR /app
+
+# Set the working directory to the sample application
+WORKDIR /app/Samples/TypeScript/Demo
+
+# Install the demo's dependencies
 COPY Samples/TypeScript/Demo/package*.json ./
 RUN npm install
-COPY Samples/TypeScript/Demo ./
+
+# Copy the Cubism SDK resources used by the demo
+COPY Core /app/Core
+COPY Framework /app/Framework
+COPY Samples/Resources /app/Samples/Resources
+COPY Samples/TypeScript/Demo /app/Samples/TypeScript/Demo
+
 EXPOSE 5000
-CMD ["npm","start"]
+
+# Start the application
+CMD ["npm", "start"]


### PR DESCRIPTION
## Summary
- update Dockerfile to copy Cubism SDK resources so `npm start` works in container

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cc4850f8c832fa8b93cefa1c33b94